### PR TITLE
Bump pyshacl version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     zip_safe=False,
     include_package_data=True,
     package_data = { 'codemeta': ['schema/crosswalk.csv', 'schema/codemeta.jsonld', 'templates/*.html','resources/*.css', 'resources/fa-*' ] },
-    install_requires=[ 'nameparser','importlib_metadata','BeautifulSoup4', 'rdflib >= 6.1.1','pyshacl == 0.20.0', 'requests','lxml','pyyaml','pep517','tomlkit','pyproject_parser', 'setuptools'],
+    install_requires=[ 'nameparser','importlib_metadata','BeautifulSoup4', 'rdflib >= 6.1.1','pyshacl >= 0.31.0', 'requests','lxml','pyyaml','pep517','tomlkit','pyproject_parser', 'setuptools'],
     entry_points = {    'console_scripts': [ 'codemetapy = codemeta.codemeta:main' ] },
     cmdclass=cmdclass
 )


### PR DESCRIPTION
pySHACL 0.20.0 is relatively old now and uses some deprecated features. This causes codemetapy and codemeta2html to not work on some systems. As best I can tell, there are no breaking changes in the pyshacl validate interface, so just simply bumping the version should be enough to fix these.